### PR TITLE
fix(xmbctrl): Fix XMB plugin manager writing the enable state twice on some cases

### DIFF
--- a/cef/xmbctrl/plugins.c
+++ b/cef/xmbctrl/plugins.c
@@ -111,17 +111,16 @@ void savePlugins() {
 	for (int i = 0; i < plugins.count; i++) {
 		Plugin *plugin = (Plugin *)(plugins.table[i]);
 		if (fd[plugin->place] != -1) {
-			if (plugin->active == PLUGIN_REMOVED)
+			if (plugin->active == PLUGIN_REMOVED) {
 				continue;
-
-			sceIoWrite(fd[plugin->place], plugin->path, strlen(plugin->path));
-			if (plugin->name != NULL) {
-				char *sep = " ";
-				char *enabled = (plugin->active) ? "1" : "0";
-				sceIoWrite(fd[plugin->place], sep, 1);
-				sceIoWrite(fd[plugin->place], enabled, strlen(enabled));
 			}
-			sceIoWrite(fd[plugin->place], "\n", 1);
+
+			if (plugin->name != NULL) {
+				char buf[128] = {0};
+				char *enabled = (plugin->active) ? "1" : "0";
+				sprintf(buf, "%s %s\n", plugin->path, enabled);
+				sceIoWrite(fd[plugin->place], buf, strlen(buf));
+			}
 		}
 	}
 


### PR DESCRIPTION
XMB Plugin manager was writing the plugin state twice sometimes.

This fix simply issue one write call for the hole line instead of multiple small write calls.

