### PR TITLE
SystemCtrl

### DIFF
--- a/cef/include/systemctrl.h
+++ b/cef/include/systemctrl.h
@@ -177,6 +177,23 @@ u32 sctrlHENFindFunction(const char* szMod, const char* szLib, u32 nid);
 #define FindProc sctrlHENFindFunction
 
 /**
+ * Replace import function stub with a function or dummy value.
+ *
+ * @param mod - The module where to search the function
+ * @param library - The library name
+ * @param nid - The nid of the function
+ * @param func - The function to replace the stub. If NULL, use dummy value
+ * @param dummy - The dummy value to replace the stub
+ *
+ * @returns 0 if successful,
+ * -1 if `mod` or `library` are NULL,
+ * -2 if failed to find import by NID and fail to resolve that NID from older firmware version
+ * -3 if failed to find import by NID after successful resolve to older firmware version
+ *
+*/
+int sctrlHENHookImportByNID(SceModule2 * mod, char *library, u32 nid, void *func, int dummy);
+
+/**
  * Gets the HEN version
  *
  * @returns - The HEN version

--- a/cef/include/systemctrl.h
+++ b/cef/include/systemctrl.h
@@ -179,6 +179,9 @@ u32 sctrlHENFindFunction(const char* szMod, const char* szLib, u32 nid);
 /**
  * Replace import function stub with a function or dummy value.
  *
+ * This function autodetects whether Syscalls are used or not, but manually
+ * exporting in exports.exp is still required for Syscalls to work.
+ *
  * @param mod - The module where to search the function
  * @param library - The library name
  * @param nid - The nid of the function

--- a/cef/include/systemctrl.h
+++ b/cef/include/systemctrl.h
@@ -304,18 +304,48 @@ int sctrlRebootDevice();
 #endif
 
 /**
- * LZ4 decompress
+ * LZ4 decompress.
+ *
+ * @param dest out buffer where the decompressed data will be
+ * @param src source buffer with the compressed data
+ * @param size size of the decompressed data
  */
-int LZ4_decompress_fast(const char* source, char* dest, int outputSize);
+int sctrlLZ4Decompress(void* dest, const void* src, int size);
 
 /**
- * LZO decompress
+ * LZO decompress.
+ *
+ * @param dest out buffer where the decompressed data will be
+ * @param dst_size return size of the decompressed data
+ * @param src source buffer with the compressed data
+ * @param src_size size of the compressed data
  */
-int lzo1x_decompress(void* source, unsigned src_len, void* dest, unsigned* dst_len, void*);
+int sctrlLzoDecompress(void* dest, unsigned* dst_size, void* src, unsigned src_size);
 
 
 // USER ONLY
 #ifdef __USER__
+
+/**
+ * Wrapper for sceKernelDeflateDecompress.
+ *
+ * @param dest out buffer where the decompressed data will be
+ * @param src source buffer with the compressed data
+ * @param size size of the decompressed data
+ *
+ */
+int sctrlDeflateDecompress(void* dest, void* src, int size);
+
+/**
+ * GZIP decompress.
+ * Wrapper for sceKernelGzipDecompress.
+ *
+ * @param dest out buffer where the decompressed data will be
+ * @param src source buffer with the compressed data
+ * @param size size of the decompressed data
+ *
+ */
+int sctrlGzipDecompress(void* dest, void* src, int size);
 
 #endif // __USER__
 

--- a/cef/inferno/isoread.c
+++ b/cef/inferno/isoread.c
@@ -32,7 +32,6 @@
 #include "inferno.h"
 #include "lz4.h"
 
-int lzo1x_decompress(void* source, unsigned src_len, void* dest, unsigned* dst_len, void*);
 
 #define CSO_MAGIC 0x4F534943 // CISO
 #define ZSO_MAGIC 0x4F53495A // ZISO
@@ -375,7 +374,7 @@ static void decompress_dax1(void* src, int src_len, void* dst, int dst_len, u32 
 static void decompress_jiso(void* src, int src_len, void* dst, int dst_len, u32 topbit){
     // while JISO allows for DAX-like NCarea, it by default uses compressed size check
     if (src_len == dst_len) memcpy(dst, src, dst_len); // check for NC area
-    else lzo1x_decompress(src, src_len, dst, &dst_len, 0); // use lzo
+	else sctrlLzoDecompress(dst, &dst_len, src, src_len); // use lzo
 }
 
 // Decompress CISO v1
@@ -387,14 +386,14 @@ static void decompress_ciso(void* src, int src_len, void* dst, int dst_len, u32 
 // Decompress ZISO
 static void decompress_ziso(void* src, int src_len, void* dst, int dst_len, u32 topbit){
     if (topbit) memcpy(dst, src, dst_len); // check for NC area
-    else LZ4_decompress_fast(src, dst, dst_len);
+    else sctrlLZ4Decompress(dst, src, dst_len);
 }
 
 // Decompress CISO v2
 static void decompress_cso2(void* src, int src_len, void* dst, int dst_len, u32 topbit){
     // in CSOv2, top bit represents compression method instead of NCarea
     if (src_len >= dst_len) memcpy(dst, src, dst_len); // check for NC area (JSO-like, but considering padding, thus >=)
-    else if (topbit) LZ4_decompress_fast(src, dst, dst_len);
+    else if (topbit) sctrlLZ4Decompress(dst, src, dst_len);
     else sceKernelDeflateDecompress(dst, dst_len, src, 0);
 }
 

--- a/cef/lib/libpspsystemctrl_kernel/Makefile
+++ b/cef/lib/libpspsystemctrl_kernel/Makefile
@@ -60,7 +60,8 @@ OBJS = \
 	SystemCtrlForKernel_0057.o \
 	SystemCtrlForKernel_0058.o \
 	SystemCtrlForKernel_0059.o \
-	SystemCtrlForKernel_0060.o
+	SystemCtrlForKernel_0060.o \
+	SystemCtrlForKernel_0061.o
 
 
 %.o: SystemCtrlForKernel.S

--- a/cef/lib/libpspsystemctrl_kernel/SystemCtrlForKernel.S
+++ b/cef/lib/libpspsystemctrl_kernel/SystemCtrlForKernel.S
@@ -18,173 +18,176 @@
 	IMPORT_FUNC  "SystemCtrlForKernel",0x1090A2E1,sctrlHENGetVersion
 #endif
 #ifdef F_SystemCtrlForKernel_0004
-	IMPORT_FUNC  "SystemCtrlForKernel",0x2E2935EF,sctrlHENIsDevhook
+	IMPORT_FUNC  "SystemCtrlForKernel",0xD6075560,sctrlHENHookImportByNID
 #endif
 #ifdef F_SystemCtrlForKernel_0005
-	IMPORT_FUNC  "SystemCtrlForKernel",0xD339E2E9,sctrlHENIsSE
+	IMPORT_FUNC  "SystemCtrlForKernel",0x2E2935EF,sctrlHENIsDevhook
 #endif
 #ifdef F_SystemCtrlForKernel_0006
-	IMPORT_FUNC  "SystemCtrlForKernel",0xC4D88D50,sctrlHENIsSystemBooted
+	IMPORT_FUNC  "SystemCtrlForKernel",0xD339E2E9,sctrlHENIsSE
 #endif
 #ifdef F_SystemCtrlForKernel_0007
-	IMPORT_FUNC  "SystemCtrlForKernel",0x745286D1,sctrlHENSetMemory
+	IMPORT_FUNC  "SystemCtrlForKernel",0xC4D88D50,sctrlHENIsSystemBooted
 #endif
 #ifdef F_SystemCtrlForKernel_0008
-	IMPORT_FUNC  "SystemCtrlForKernel",0xCC9ADCF8,sctrlHENSetSpeed
+	IMPORT_FUNC  "SystemCtrlForKernel",0x745286D1,sctrlHENSetMemory
 #endif
 #ifdef F_SystemCtrlForKernel_0009
-	IMPORT_FUNC  "SystemCtrlForKernel",0x1C90BECB,sctrlHENSetStartModuleHandler
+	IMPORT_FUNC  "SystemCtrlForKernel",0xCC9ADCF8,sctrlHENSetSpeed
 #endif
 #ifdef F_SystemCtrlForKernel_0010
-	IMPORT_FUNC  "SystemCtrlForKernel",0xCE0A654E,sctrlHENLoadModuleOnReboot
+	IMPORT_FUNC  "SystemCtrlForKernel",0x1C90BECB,sctrlHENSetStartModuleHandler
 #endif
 #ifdef F_SystemCtrlForKernel_0011
-	IMPORT_FUNC  "SystemCtrlForKernel",0xF988C1DC,sctrlHENPatchSyscall
+	IMPORT_FUNC  "SystemCtrlForKernel",0xCE0A654E,sctrlHENLoadModuleOnReboot
 #endif
 #ifdef F_SystemCtrlForKernel_0012
-	IMPORT_FUNC  "SystemCtrlForKernel",0x826668E9,sctrlHENPatchSyscall
+	IMPORT_FUNC  "SystemCtrlForKernel",0xF988C1DC,sctrlHENPatchSyscall
 #endif
 #ifdef F_SystemCtrlForKernel_0013
-	IMPORT_FUNC  "SystemCtrlForKernel",0x02BFCB5F,sctrlHENPatchSyscall
+	IMPORT_FUNC  "SystemCtrlForKernel",0x826668E9,sctrlHENPatchSyscall
 #endif
 #ifdef F_SystemCtrlForKernel_0014
-	IMPORT_FUNC  "SystemCtrlForKernel",0x07232EA5,sctrlHENRegisterHomebrewLoader
+	IMPORT_FUNC  "SystemCtrlForKernel",0x02BFCB5F,sctrlHENPatchSyscall
 #endif
 #ifdef F_SystemCtrlForKernel_0015
-	IMPORT_FUNC  "SystemCtrlForKernel",0x2794CCF4,sctrlKernelExitVSH
+	IMPORT_FUNC  "SystemCtrlForKernel",0x07232EA5,sctrlHENRegisterHomebrewLoader
 #endif
 #ifdef F_SystemCtrlForKernel_0016
-	IMPORT_FUNC  "SystemCtrlForKernel",0x577AF198,sctrlKernelLoadExecVSHDisc
+	IMPORT_FUNC  "SystemCtrlForKernel",0x2794CCF4,sctrlKernelExitVSH
 #endif
 #ifdef F_SystemCtrlForKernel_0017
-	IMPORT_FUNC  "SystemCtrlForKernel",0x94FE5E4B,sctrlKernelLoadExecVSHDiscUpdater
+	IMPORT_FUNC  "SystemCtrlForKernel",0x577AF198,sctrlKernelLoadExecVSHDisc
 #endif
 #ifdef F_SystemCtrlForKernel_0018
-	IMPORT_FUNC  "SystemCtrlForKernel",0x75643FCA,sctrlKernelLoadExecVSHMs1
+	IMPORT_FUNC  "SystemCtrlForKernel",0x94FE5E4B,sctrlKernelLoadExecVSHDiscUpdater
 #endif
 #ifdef F_SystemCtrlForKernel_0019
-	IMPORT_FUNC  "SystemCtrlForKernel",0xABA7F1B0,sctrlKernelLoadExecVSHMs2
+	IMPORT_FUNC  "SystemCtrlForKernel",0x75643FCA,sctrlKernelLoadExecVSHMs1
 #endif
 #ifdef F_SystemCtrlForKernel_0020
-	IMPORT_FUNC  "SystemCtrlForKernel",0x7B369596,sctrlKernelLoadExecVSHMs3
+	IMPORT_FUNC  "SystemCtrlForKernel",0xABA7F1B0,sctrlKernelLoadExecVSHMs2
 #endif
 #ifdef F_SystemCtrlForKernel_0021
-	IMPORT_FUNC  "SystemCtrlForKernel",0xD690750F,sctrlKernelLoadExecVSHMs4
+	IMPORT_FUNC  "SystemCtrlForKernel",0x7B369596,sctrlKernelLoadExecVSHMs3
 #endif
 #ifdef F_SystemCtrlForKernel_0022
-	IMPORT_FUNC  "SystemCtrlForKernel",0x2D10FB28,sctrlKernelLoadExecVSHWithApitype
+	IMPORT_FUNC  "SystemCtrlForKernel",0xD690750F,sctrlKernelLoadExecVSHMs4
 #endif
 #ifdef F_SystemCtrlForKernel_0023
-	IMPORT_FUNC  "SystemCtrlForKernel",0x56CEAF00,sctrlKernelQuerySystemCall
+	IMPORT_FUNC  "SystemCtrlForKernel",0x2D10FB28,sctrlKernelLoadExecVSHWithApitype
 #endif
 #ifdef F_SystemCtrlForKernel_0024
-	IMPORT_FUNC  "SystemCtrlForKernel",0xB364FBB4,sctrlKernelRand
+	IMPORT_FUNC  "SystemCtrlForKernel",0x56CEAF00,sctrlKernelQuerySystemCall
 #endif
 #ifdef F_SystemCtrlForKernel_0025
-	IMPORT_FUNC  "SystemCtrlForKernel",0xEB74FE45,sctrlKernelSetUserLevel
+	IMPORT_FUNC  "SystemCtrlForKernel",0xB364FBB4,sctrlKernelRand
 #endif
 #ifdef F_SystemCtrlForKernel_0026
-	IMPORT_FUNC  "SystemCtrlForKernel",0x16C3B7EE,sctrlSEGetConfig
+	IMPORT_FUNC  "SystemCtrlForKernel",0xEB74FE45,sctrlKernelSetUserLevel
 #endif
 #ifdef F_SystemCtrlForKernel_0027
-	IMPORT_FUNC  "SystemCtrlForKernel",0x8E426F09,sctrlSEGetConfigEx
+	IMPORT_FUNC  "SystemCtrlForKernel",0x16C3B7EE,sctrlSEGetConfig
 #endif
 #ifdef F_SystemCtrlForKernel_0028
-	IMPORT_FUNC  "SystemCtrlForKernel",0xABEF849B,sctrlSEGetDiscType
+	IMPORT_FUNC  "SystemCtrlForKernel",0x8E426F09,sctrlSEGetConfigEx
 #endif
 #ifdef F_SystemCtrlForKernel_0029
-	IMPORT_FUNC  "SystemCtrlForKernel",0xB47C9D77,sctrlSEGetVersion
+	IMPORT_FUNC  "SystemCtrlForKernel",0xABEF849B,sctrlSEGetDiscType
 #endif
 #ifdef F_SystemCtrlForKernel_0030
-	IMPORT_FUNC  "SystemCtrlForKernel",0x85B520C6,sctrlSEMountUmdFromFile
+	IMPORT_FUNC  "SystemCtrlForKernel",0xB47C9D77,sctrlSEGetVersion
 #endif
 #ifdef F_SystemCtrlForKernel_0031
-	IMPORT_FUNC  "SystemCtrlForKernel",0x1DDDAD0C,sctrlSESetConfig
+	IMPORT_FUNC  "SystemCtrlForKernel",0x85B520C6,sctrlSEMountUmdFromFile
 #endif
 #ifdef F_SystemCtrlForKernel_0032
-	IMPORT_FUNC  "SystemCtrlForKernel",0xAD4D5EA5,sctrlSESetConfigEx
+	IMPORT_FUNC  "SystemCtrlForKernel",0x1DDDAD0C,sctrlSESetConfig
 #endif
 #ifdef F_SystemCtrlForKernel_0033
-	IMPORT_FUNC  "SystemCtrlForKernel",0x31C6160D,sctrlSESetDiscType
+	IMPORT_FUNC  "SystemCtrlForKernel",0xAD4D5EA5,sctrlSESetConfigEx
 #endif
 #ifdef F_SystemCtrlForKernel_0034
-	IMPORT_FUNC  "SystemCtrlForKernel",0x5CB025F0,sctrlSESetBootConfFileIndex
+	IMPORT_FUNC  "SystemCtrlForKernel",0x31C6160D,sctrlSESetDiscType
 #endif
 #ifdef F_SystemCtrlForKernel_0035
-	IMPORT_FUNC  "SystemCtrlForKernel",0xAC56B90B,GetUmdFile
+	IMPORT_FUNC  "SystemCtrlForKernel",0x5CB025F0,sctrlSESetBootConfFileIndex
 #endif
 #ifdef F_SystemCtrlForKernel_0036
-	IMPORT_FUNC  "SystemCtrlForKernel",0xB64186D0,SetUmdFile
+	IMPORT_FUNC  "SystemCtrlForKernel",0xAC56B90B,GetUmdFile
 #endif
 #ifdef F_SystemCtrlForKernel_0037
-	IMPORT_FUNC  "SystemCtrlForKernel",0xFFE1D172,sctrlSEApplyConfig
+	IMPORT_FUNC  "SystemCtrlForKernel",0xB64186D0,SetUmdFile
 #endif
 #ifdef F_SystemCtrlForKernel_0038
-	IMPORT_FUNC  "SystemCtrlForKernel",0x373D2D2E,sctrlSEApplyConfigEX
+	IMPORT_FUNC  "SystemCtrlForKernel",0xFFE1D172,sctrlSEApplyConfig
 #endif
 #ifdef F_SystemCtrlForKernel_0039
-	IMPORT_FUNC  "SystemCtrlForKernel",0xBA21998E,sctrlSEGetUmdFile
+	IMPORT_FUNC  "SystemCtrlForKernel",0x373D2D2E,sctrlSEApplyConfigEX
 #endif
 #ifdef F_SystemCtrlForKernel_0040
-	IMPORT_FUNC  "SystemCtrlForKernel",0x5A35C948,sctrlSESetUmdFile
+	IMPORT_FUNC  "SystemCtrlForKernel",0xBA21998E,sctrlSEGetUmdFile
 #endif
 #ifdef F_SystemCtrlForKernel_0041
-	IMPORT_FUNC  "SystemCtrlForKernel",0x16100529,LZ4_decompress_fast
+	IMPORT_FUNC  "SystemCtrlForKernel",0x5A35C948,sctrlSESetUmdFile
 #endif
 #ifdef F_SystemCtrlForKernel_0042
-	IMPORT_FUNC  "SystemCtrlForKernel",0x76C382FF,lzo1x_decompress
+	IMPORT_FUNC  "SystemCtrlForKernel",0x16100529,LZ4_decompress_fast
 #endif
 #ifdef F_SystemCtrlForKernel_0043
-	IMPORT_FUNC  "SystemCtrlForKernel",0x17691875,sctrlFlushCache
+	IMPORT_FUNC  "SystemCtrlForKernel",0x76C382FF,lzo1x_decompress
 #endif
 #ifdef F_SystemCtrlForKernel_0044
-	IMPORT_FUNC  "SystemCtrlForKernel",0x05D8E209,sctrlGetUsbState
+	IMPORT_FUNC  "SystemCtrlForKernel",0x17691875,sctrlFlushCache
 #endif
 #ifdef F_SystemCtrlForKernel_0045
-	IMPORT_FUNC  "SystemCtrlForKernel",0x053172F8,sctrlRebootDevice
+	IMPORT_FUNC  "SystemCtrlForKernel",0x05D8E209,sctrlGetUsbState
 #endif
 #ifdef F_SystemCtrlForKernel_0046
-	IMPORT_FUNC  "SystemCtrlForKernel",0x80C0ED7B,sctrlStartUsb
+	IMPORT_FUNC  "SystemCtrlForKernel",0x053172F8,sctrlRebootDevice
 #endif
 #ifdef F_SystemCtrlForKernel_0047
-	IMPORT_FUNC  "SystemCtrlForKernel",0x5FC12767,sctrlStopUsb
+	IMPORT_FUNC  "SystemCtrlForKernel",0x80C0ED7B,sctrlStartUsb
 #endif
 #ifdef F_SystemCtrlForKernel_0048
-	IMPORT_FUNC  "SystemCtrlForKernel",0xB86E36D1,ApplyMemory
+	IMPORT_FUNC  "SystemCtrlForKernel",0x5FC12767,sctrlStopUsb
 #endif
 #ifdef F_SystemCtrlForKernel_0049
-	IMPORT_FUNC  "SystemCtrlForKernel",0x98012538,SetSpeed
+	IMPORT_FUNC  "SystemCtrlForKernel",0xB86E36D1,ApplyMemory
 #endif
 #ifdef F_SystemCtrlForKernel_0050
-	IMPORT_FUNC  "SystemCtrlForKernel",0x983B00FB,lowerString
+	IMPORT_FUNC  "SystemCtrlForKernel",0x98012538,SetSpeed
 #endif
 #ifdef F_SystemCtrlForKernel_0051
-	IMPORT_FUNC  "SystemCtrlForKernel",0xA65E8BC4,oe_free
+	IMPORT_FUNC  "SystemCtrlForKernel",0x983B00FB,lowerString
 #endif
 #ifdef F_SystemCtrlForKernel_0052
-	IMPORT_FUNC  "SystemCtrlForKernel",0xF9584CAD,oe_malloc
+	IMPORT_FUNC  "SystemCtrlForKernel",0xA65E8BC4,oe_free
 #endif
 #ifdef F_SystemCtrlForKernel_0053
-	IMPORT_FUNC  "SystemCtrlForKernel",0x3EB35691,strcasecmp
+	IMPORT_FUNC  "SystemCtrlForKernel",0xF9584CAD,oe_malloc
 #endif
 #ifdef F_SystemCtrlForKernel_0054
-	IMPORT_FUNC  "SystemCtrlForKernel",0x7BA27B01,strncasecmp
+	IMPORT_FUNC  "SystemCtrlForKernel",0x3EB35691,strcasecmp
 #endif
 #ifdef F_SystemCtrlForKernel_0055
-	IMPORT_FUNC  "SystemCtrlForKernel",0xD3D1A3B9,strncat
+	IMPORT_FUNC  "SystemCtrlForKernel",0x7BA27B01,strncasecmp
 #endif
 #ifdef F_SystemCtrlForKernel_0056
-	IMPORT_FUNC  "SystemCtrlForKernel",0xEFB593C9,strncat_s
+	IMPORT_FUNC  "SystemCtrlForKernel",0xD3D1A3B9,strncat
 #endif
 #ifdef F_SystemCtrlForKernel_0057
-	IMPORT_FUNC  "SystemCtrlForKernel",0x5ABF13F5,strncpy_s
+	IMPORT_FUNC  "SystemCtrlForKernel",0xEFB593C9,strncat_s
 #endif
 #ifdef F_SystemCtrlForKernel_0058
-	IMPORT_FUNC  "SystemCtrlForKernel",0x12BC667F,user_free
+	IMPORT_FUNC  "SystemCtrlForKernel",0x5ABF13F5,strncpy_s
 #endif
 #ifdef F_SystemCtrlForKernel_0059
-	IMPORT_FUNC  "SystemCtrlForKernel",0x4C0FE24C,user_malloc
+	IMPORT_FUNC  "SystemCtrlForKernel",0x12BC667F,user_free
 #endif
 #ifdef F_SystemCtrlForKernel_0060
+	IMPORT_FUNC  "SystemCtrlForKernel",0x4C0FE24C,user_malloc
+#endif
+#ifdef F_SystemCtrlForKernel_0061
 	IMPORT_FUNC  "SystemCtrlForKernel",0xB19C939A,user_memalign
 #endif

--- a/cef/lib/libpspsystemctrl_kernel/SystemCtrlForKernel.S
+++ b/cef/lib/libpspsystemctrl_kernel/SystemCtrlForKernel.S
@@ -132,16 +132,16 @@
 	IMPORT_FUNC  "SystemCtrlForKernel",0x5A35C948,sctrlSESetUmdFile
 #endif
 #ifdef F_SystemCtrlForKernel_0042
-	IMPORT_FUNC  "SystemCtrlForKernel",0x16100529,LZ4_decompress_fast
-#endif
-#ifdef F_SystemCtrlForKernel_0043
-	IMPORT_FUNC  "SystemCtrlForKernel",0x76C382FF,lzo1x_decompress
-#endif
-#ifdef F_SystemCtrlForKernel_0044
 	IMPORT_FUNC  "SystemCtrlForKernel",0x17691875,sctrlFlushCache
 #endif
-#ifdef F_SystemCtrlForKernel_0045
+#ifdef F_SystemCtrlForKernel_0043
 	IMPORT_FUNC  "SystemCtrlForKernel",0x05D8E209,sctrlGetUsbState
+#endif
+#ifdef F_SystemCtrlForKernel_0044
+	IMPORT_FUNC  "SystemCtrlForKernel",0xFE84B359,sctrlLZ4Decompress
+#endif
+#ifdef F_SystemCtrlForKernel_0045
+	IMPORT_FUNC  "SystemCtrlForKernel",0xCF03305A,sctrlLzoDecompress
 #endif
 #ifdef F_SystemCtrlForKernel_0046
 	IMPORT_FUNC  "SystemCtrlForKernel",0x053172F8,sctrlRebootDevice

--- a/cef/lib/libpspsystemctrl_user/Makefile
+++ b/cef/lib/libpspsystemctrl_user/Makefile
@@ -37,7 +37,9 @@ OBJS = \
 	SystemCtrlForUser_0034.o \
 	SystemCtrlForUser_0035.o \
 	SystemCtrlForUser_0036.o \
-	SystemCtrlForUser_0037.o
+	SystemCtrlForUser_0037.o \
+	SystemCtrlForUser_0038.o \
+	SystemCtrlForUser_0039.o
 
 
 %.o: SystemCtrlForUser.S

--- a/cef/lib/libpspsystemctrl_user/Makefile
+++ b/cef/lib/libpspsystemctrl_user/Makefile
@@ -36,7 +36,8 @@ OBJS = \
 	SystemCtrlForUser_0033.o \
 	SystemCtrlForUser_0034.o \
 	SystemCtrlForUser_0035.o \
-	SystemCtrlForUser_0036.o
+	SystemCtrlForUser_0036.o \
+	SystemCtrlForUser_0037.o
 
 
 %.o: SystemCtrlForUser.S

--- a/cef/lib/libpspsystemctrl_user/SystemCtrlForUser.S
+++ b/cef/lib/libpspsystemctrl_user/SystemCtrlForUser.S
@@ -105,17 +105,23 @@
 	IMPORT_FUNC  "SystemCtrlForUser",0x5CB025F0,sctrlSESetBootConfFileIndex
 #endif
 #ifdef F_SystemCtrlForUser_0033
-	IMPORT_FUNC  "SystemCtrlForUser",0x16100529,LZ4_decompress_fast
-#endif
-#ifdef F_SystemCtrlForUser_0034
-	IMPORT_FUNC  "SystemCtrlForUser",0x76C382FF,lzo1x_decompress
-#endif
-#ifdef F_SystemCtrlForUser_0035
 	IMPORT_FUNC  "SystemCtrlForUser",0x17691875,sctrlFlushCache
 #endif
-#ifdef F_SystemCtrlForUser_0036
+#ifdef F_SystemCtrlForUser_0034
 	IMPORT_FUNC  "SystemCtrlForUser",0x05D8E209,sctrlGetUsbState
+#endif
+#ifdef F_SystemCtrlForUser_0035
+	IMPORT_FUNC  "SystemCtrlForUser",0xFE84B359,sctrlLZ4Decompress
+#endif
+#ifdef F_SystemCtrlForUser_0036
+	IMPORT_FUNC  "SystemCtrlForUser",0xCF03305A,sctrlLzoDecompress
 #endif
 #ifdef F_SystemCtrlForUser_0037
 	IMPORT_FUNC  "SystemCtrlForUser",0x053172F8,sctrlRebootDevice
+#endif
+#ifdef F_SystemCtrlForUser_0038
+	IMPORT_FUNC  "SystemCtrlForUser",0xF462EE55,sctrlDeflateDecompress
+#endif
+#ifdef F_SystemCtrlForUser_0039
+	IMPORT_FUNC  "SystemCtrlForUser",0x5D665044,sctrlGzipDecompress
 #endif

--- a/cef/lib/libpspsystemctrl_user/SystemCtrlForUser.S
+++ b/cef/lib/libpspsystemctrl_user/SystemCtrlForUser.S
@@ -18,101 +18,104 @@
 	IMPORT_FUNC  "SystemCtrlForUser",0x1090A2E1,sctrlHENGetVersion
 #endif
 #ifdef F_SystemCtrlForUser_0004
-	IMPORT_FUNC  "SystemCtrlForUser",0x2E2935EF,sctrlHENIsDevhook
+	IMPORT_FUNC  "SystemCtrlForUser",0xD6075560,sctrlHENHookImportByNID
 #endif
 #ifdef F_SystemCtrlForUser_0005
-	IMPORT_FUNC  "SystemCtrlForUser",0xD339E2E9,sctrlHENIsSE
+	IMPORT_FUNC  "SystemCtrlForUser",0x2E2935EF,sctrlHENIsDevhook
 #endif
 #ifdef F_SystemCtrlForUser_0006
-	IMPORT_FUNC  "SystemCtrlForUser",0xC4D88D50,sctrlHENIsSystemBooted
+	IMPORT_FUNC  "SystemCtrlForUser",0xD339E2E9,sctrlHENIsSE
 #endif
 #ifdef F_SystemCtrlForUser_0007
-	IMPORT_FUNC  "SystemCtrlForUser",0x745286D1,sctrlHENSetMemory
+	IMPORT_FUNC  "SystemCtrlForUser",0xC4D88D50,sctrlHENIsSystemBooted
 #endif
 #ifdef F_SystemCtrlForUser_0008
-	IMPORT_FUNC  "SystemCtrlForUser",0xCC9ADCF8,sctrlHENSetSpeed
+	IMPORT_FUNC  "SystemCtrlForUser",0x745286D1,sctrlHENSetMemory
 #endif
 #ifdef F_SystemCtrlForUser_0009
-	IMPORT_FUNC  "SystemCtrlForUser",0x1C90BECB,sctrlHENSetStartModuleHandler
+	IMPORT_FUNC  "SystemCtrlForUser",0xCC9ADCF8,sctrlHENSetSpeed
 #endif
 #ifdef F_SystemCtrlForUser_0010
-	IMPORT_FUNC  "SystemCtrlForUser",0x2794CCF4,sctrlKernelExitVSH
+	IMPORT_FUNC  "SystemCtrlForUser",0x1C90BECB,sctrlHENSetStartModuleHandler
 #endif
 #ifdef F_SystemCtrlForUser_0011
-	IMPORT_FUNC  "SystemCtrlForUser",0x577AF198,sctrlKernelLoadExecVSHDisc
+	IMPORT_FUNC  "SystemCtrlForUser",0x2794CCF4,sctrlKernelExitVSH
 #endif
 #ifdef F_SystemCtrlForUser_0012
-	IMPORT_FUNC  "SystemCtrlForUser",0x94FE5E4B,sctrlKernelLoadExecVSHDiscUpdater
+	IMPORT_FUNC  "SystemCtrlForUser",0x577AF198,sctrlKernelLoadExecVSHDisc
 #endif
 #ifdef F_SystemCtrlForUser_0013
-	IMPORT_FUNC  "SystemCtrlForUser",0x75643FCA,sctrlKernelLoadExecVSHMs1
+	IMPORT_FUNC  "SystemCtrlForUser",0x94FE5E4B,sctrlKernelLoadExecVSHDiscUpdater
 #endif
 #ifdef F_SystemCtrlForUser_0014
-	IMPORT_FUNC  "SystemCtrlForUser",0xABA7F1B0,sctrlKernelLoadExecVSHMs2
+	IMPORT_FUNC  "SystemCtrlForUser",0x75643FCA,sctrlKernelLoadExecVSHMs1
 #endif
 #ifdef F_SystemCtrlForUser_0015
-	IMPORT_FUNC  "SystemCtrlForUser",0x7B369596,sctrlKernelLoadExecVSHMs3
+	IMPORT_FUNC  "SystemCtrlForUser",0xABA7F1B0,sctrlKernelLoadExecVSHMs2
 #endif
 #ifdef F_SystemCtrlForUser_0016
-	IMPORT_FUNC  "SystemCtrlForUser",0xD690750F,sctrlKernelLoadExecVSHMs4
+	IMPORT_FUNC  "SystemCtrlForUser",0x7B369596,sctrlKernelLoadExecVSHMs3
 #endif
 #ifdef F_SystemCtrlForUser_0017
-	IMPORT_FUNC  "SystemCtrlForUser",0x2D10FB28,sctrlKernelLoadExecVSHWithApitype
+	IMPORT_FUNC  "SystemCtrlForUser",0xD690750F,sctrlKernelLoadExecVSHMs4
 #endif
 #ifdef F_SystemCtrlForUser_0018
-	IMPORT_FUNC  "SystemCtrlForUser",0x56CEAF00,sctrlKernelQuerySystemCall
+	IMPORT_FUNC  "SystemCtrlForUser",0x2D10FB28,sctrlKernelLoadExecVSHWithApitype
 #endif
 #ifdef F_SystemCtrlForUser_0019
-	IMPORT_FUNC  "SystemCtrlForUser",0xB364FBB4,sctrlKernelRand
+	IMPORT_FUNC  "SystemCtrlForUser",0x56CEAF00,sctrlKernelQuerySystemCall
 #endif
 #ifdef F_SystemCtrlForUser_0020
-	IMPORT_FUNC  "SystemCtrlForUser",0xEB74FE45,sctrlKernelSetUserLevel
+	IMPORT_FUNC  "SystemCtrlForUser",0xB364FBB4,sctrlKernelRand
 #endif
 #ifdef F_SystemCtrlForUser_0021
-	IMPORT_FUNC  "SystemCtrlForUser",0x16C3B7EE,sctrlSEGetConfig
+	IMPORT_FUNC  "SystemCtrlForUser",0xEB74FE45,sctrlKernelSetUserLevel
 #endif
 #ifdef F_SystemCtrlForUser_0022
-	IMPORT_FUNC  "SystemCtrlForUser",0x8E426F09,sctrlSEGetConfigEx
+	IMPORT_FUNC  "SystemCtrlForUser",0x16C3B7EE,sctrlSEGetConfig
 #endif
 #ifdef F_SystemCtrlForUser_0023
-	IMPORT_FUNC  "SystemCtrlForUser",0xABEF849B,sctrlSEGetDiscType
+	IMPORT_FUNC  "SystemCtrlForUser",0x8E426F09,sctrlSEGetConfigEx
 #endif
 #ifdef F_SystemCtrlForUser_0024
-	IMPORT_FUNC  "SystemCtrlForUser",0xB47C9D77,sctrlSEGetVersion
+	IMPORT_FUNC  "SystemCtrlForUser",0xABEF849B,sctrlSEGetDiscType
 #endif
 #ifdef F_SystemCtrlForUser_0025
-	IMPORT_FUNC  "SystemCtrlForUser",0x85B520C6,sctrlSEMountUmdFromFile
+	IMPORT_FUNC  "SystemCtrlForUser",0xB47C9D77,sctrlSEGetVersion
 #endif
 #ifdef F_SystemCtrlForUser_0026
-	IMPORT_FUNC  "SystemCtrlForUser",0x1DDDAD0C,sctrlSESetConfig
+	IMPORT_FUNC  "SystemCtrlForUser",0x85B520C6,sctrlSEMountUmdFromFile
 #endif
 #ifdef F_SystemCtrlForUser_0027
-	IMPORT_FUNC  "SystemCtrlForUser",0xAD4D5EA5,sctrlSESetConfigEx
+	IMPORT_FUNC  "SystemCtrlForUser",0x1DDDAD0C,sctrlSESetConfig
 #endif
 #ifdef F_SystemCtrlForUser_0028
-	IMPORT_FUNC  "SystemCtrlForUser",0x31C6160D,sctrlSESetDiscType
+	IMPORT_FUNC  "SystemCtrlForUser",0xAD4D5EA5,sctrlSESetConfigEx
 #endif
 #ifdef F_SystemCtrlForUser_0029
-	IMPORT_FUNC  "SystemCtrlForUser",0x80C0ED7B,sctrlStartUsb
+	IMPORT_FUNC  "SystemCtrlForUser",0x31C6160D,sctrlSESetDiscType
 #endif
 #ifdef F_SystemCtrlForUser_0030
-	IMPORT_FUNC  "SystemCtrlForUser",0x5FC12767,sctrlStopUsb
+	IMPORT_FUNC  "SystemCtrlForUser",0x80C0ED7B,sctrlStartUsb
 #endif
 #ifdef F_SystemCtrlForUser_0031
-	IMPORT_FUNC  "SystemCtrlForUser",0x5CB025F0,sctrlSESetBootConfFileIndex
+	IMPORT_FUNC  "SystemCtrlForUser",0x5FC12767,sctrlStopUsb
 #endif
 #ifdef F_SystemCtrlForUser_0032
-	IMPORT_FUNC  "SystemCtrlForUser",0x16100529,LZ4_decompress_fast
+	IMPORT_FUNC  "SystemCtrlForUser",0x5CB025F0,sctrlSESetBootConfFileIndex
 #endif
 #ifdef F_SystemCtrlForUser_0033
-	IMPORT_FUNC  "SystemCtrlForUser",0x76C382FF,lzo1x_decompress
+	IMPORT_FUNC  "SystemCtrlForUser",0x16100529,LZ4_decompress_fast
 #endif
 #ifdef F_SystemCtrlForUser_0034
-	IMPORT_FUNC  "SystemCtrlForUser",0x17691875,sctrlFlushCache
+	IMPORT_FUNC  "SystemCtrlForUser",0x76C382FF,lzo1x_decompress
 #endif
 #ifdef F_SystemCtrlForUser_0035
-	IMPORT_FUNC  "SystemCtrlForUser",0x05D8E209,sctrlGetUsbState
+	IMPORT_FUNC  "SystemCtrlForUser",0x17691875,sctrlFlushCache
 #endif
 #ifdef F_SystemCtrlForUser_0036
+	IMPORT_FUNC  "SystemCtrlForUser",0x05D8E209,sctrlGetUsbState
+#endif
+#ifdef F_SystemCtrlForUser_0037
 	IMPORT_FUNC  "SystemCtrlForUser",0x053172F8,sctrlRebootDevice
 #endif

--- a/cef/systemctrl/exports.exp
+++ b/cef/systemctrl/exports.exp
@@ -53,6 +53,7 @@ PSP_EXPORT_START(SystemCtrlForUser, 0, 0x4001)
 PSP_EXPORT_FUNC(sctrlHENFindDriver)
 PSP_EXPORT_FUNC(sctrlHENFindFunction)
 PSP_EXPORT_FUNC(sctrlHENGetVersion)
+PSP_EXPORT_FUNC(sctrlHENHookImportByNID)
 PSP_EXPORT_FUNC(sctrlHENIsDevhook)
 PSP_EXPORT_FUNC(sctrlHENIsSE)
 PSP_EXPORT_FUNC(sctrlHENIsSystemBooted)
@@ -94,11 +95,15 @@ PSP_EXPORT_FUNC_NID(sctrlSESetBootConfFileIndex, 0x5CB025F0)
 #PSP_EXPORT_FUNC(sctrlSEUmountUmd)
 
 # sctrl - other
-PSP_EXPORT_FUNC(LZ4_decompress_fast)
-PSP_EXPORT_FUNC(lzo1x_decompress)
 PSP_EXPORT_FUNC(sctrlFlushCache)
 PSP_EXPORT_FUNC(sctrlGetUsbState)
+PSP_EXPORT_FUNC(sctrlLZ4Decompress)
+PSP_EXPORT_FUNC(sctrlLzoDecompress)
 PSP_EXPORT_FUNC(sctrlRebootDevice)
+
+# sctrl - other USER EXCLUSIVE
+PSP_EXPORT_FUNC(sctrlDeflateDecompress)
+PSP_EXPORT_FUNC(sctrlGzipDecompress)
 
 PSP_EXPORT_END
 # END SystemCtrlForUser
@@ -108,12 +113,14 @@ PSP_EXPORT_START(SystemCtrlForKernel, 0, 0x0001)
 PSP_EXPORT_FUNC(sctrlHENFindDriver)
 PSP_EXPORT_FUNC(sctrlHENFindFunction)
 PSP_EXPORT_FUNC(sctrlHENGetVersion)
+PSP_EXPORT_FUNC(sctrlHENHookImportByNID)
 PSP_EXPORT_FUNC(sctrlHENIsDevhook)
 PSP_EXPORT_FUNC(sctrlHENIsSE)
 PSP_EXPORT_FUNC(sctrlHENIsSystemBooted)
 PSP_EXPORT_FUNC(sctrlHENSetMemory)
 PSP_EXPORT_FUNC(sctrlHENSetSpeed)
 PSP_EXPORT_FUNC(sctrlHENSetStartModuleHandler)
+
 # sctrlHEN - KERNEL PRIVATE
 PSP_EXPORT_FUNC(sctrlHENLoadModuleOnReboot)
 PSP_EXPORT_FUNC(sctrlHENPatchSyscall)
@@ -166,10 +173,10 @@ PSP_EXPORT_FUNC(sctrlSEGetUmdFile)
 PSP_EXPORT_FUNC(sctrlSESetUmdFile)
 
 # sctrl - COMMON
-PSP_EXPORT_FUNC(LZ4_decompress_fast)
-PSP_EXPORT_FUNC(lzo1x_decompress)
 PSP_EXPORT_FUNC(sctrlFlushCache)
 PSP_EXPORT_FUNC(sctrlGetUsbState)
+PSP_EXPORT_FUNC(sctrlLZ4Decompress)
+PSP_EXPORT_FUNC(sctrlLzoDecompress)
 PSP_EXPORT_FUNC(sctrlRebootDevice)
 PSP_EXPORT_FUNC(sctrlStartUsb)
 PSP_EXPORT_FUNC(sctrlStopUsb)

--- a/cef/systemctrl/libraries_patch.c
+++ b/cef/systemctrl/libraries_patch.c
@@ -202,6 +202,90 @@ int search_nid_in_entrytable_patched(void *lib, u32 nid, void *stub, int count) 
 	return res;
 }
 
+static u32 sctrlHENFindImportByNID(SceModule2 * mod, const char *szLib, u32 nid) {
+	int i = 0;
+	while (i < mod->stub_size) {
+		SceLibraryStubTable *stub = (SceLibraryStubTable *)(mod->stub_top + i);
+
+		if (stub->libname && strcmp(stub->libname, szLib) == 0) {
+			u32 *table = (u32 *)stub->nidtable;
+
+			int j;
+			for (j = 0; j < stub->stubcount; j++) {
+				if (table[j] == nid) {
+					return ((u32)stub->stubtable + (j * 8));
+				}
+			}
+		}
+
+		i += (stub->len * 4);
+	}
+
+	return 0;
+}
+
+// Replace Import Function Stub
+int sctrlHENHookImportByNID(SceModule2 * pMod, char * library, u32 nid, void *func, int dummy) {
+	// Invalid Arguments
+	if(pMod == NULL || library == NULL) return -1;
+
+	u32 stub = sctrlHENFindImportByNID(pMod, library, nid);
+
+	if (stub == 0) {
+
+		u32 old_nid = ResolveOldNIDs(library, nid);
+
+		// resolver fail
+		if (old_nid == 0) {
+			return -2;
+		}
+
+		stub = sctrlHENFindImportByNID(pMod, library, old_nid);
+
+		// Stub not found again...
+		if (stub == 0) {
+			return -3;
+		}
+	}
+
+	// Function as 16-Bit Unsigned Integer
+	unsigned int func_int = (unsigned int)func;
+
+	// Dummy Return
+	if (func == NULL) {
+		// Create Dummy Return
+		_sw(JR_RA, stub);
+		_sw(LI_V0(dummy), stub + 4);
+	} else if (func_int <= 0xFFFF) {
+		// Create Dummy Return
+		_sw(JR_RA, stub);
+		_sw(LI_V0(func_int), stub + 4);
+	} else { // Normal Hook
+		// Syscall Hook
+		if ((stub & 0x80000000) == 0 && (func_int & 0x80000000) != 0) {
+			// Query Syscall Number
+			int syscall = sceKernelQuerySystemCall661(func);
+
+			// Not properly exported in exports.exp
+			if(syscall < 0) return -3;
+
+			// Create Syscall Hook
+			_sw(JR_RA, stub);
+			_sw(SYSCALL(syscall), stub + 4);
+		} else { // Direct Jump Hook
+			// Create Direct Jump Hook
+			_sw(JUMP(func), stub);
+			_sw(NOP, stub + 4);
+		}
+	}
+
+	// Invalidate Cache
+	sceKernelDcacheWritebackInvalidateRange((void *)stub, 8);
+	sceKernelIcacheInvalidateRange((void *)stub, 8);
+
+	return 0;
+}
+
 int sctrlHENIsSystemBooted() {
 	int res = sceKernelGetSystemStatus661();
 


### PR DESCRIPTION
- Introduce `sctrlHENHookImportByNID` to make it easier to make hooks
- Expose Deflate and GZIP decompress to user
- Rename LZ4 and LZO decompress to make it more standard to the library