### PR TITLE
Expose more iso_common functions

### DIFF
--- a/cef/include/iso_common.h
+++ b/cef/include/iso_common.h
@@ -81,16 +81,21 @@ typedef struct IoReadArg {
 	u32 size; // 8
 } IoReadArg;
 
-extern char g_iso_fn[255];
+extern char g_iso_fn[256];
 extern SceUID g_iso_fd;
 extern int g_iso_opened;
 extern int g_total_sectors;
 extern IoReadArg g_read_arg;
 extern char* g_sector_buffer;
 
-
 int iso_read(IoReadArg *args);
 int iso_open(void);
 void iso_close(void);
+
+#ifdef __ISO_EXTRA__
+int iso_type_check(SceUID fd);
+int iso_alloc(u32 com_size);
+int iso_re_open(void);
+#endif // __ISO_EXTRA__
 
 #endif // __ISO_COMMON_H

--- a/cef/payloadex/main.c
+++ b/cef/payloadex/main.c
@@ -217,7 +217,7 @@ int loadParamsPatched(int a0) {
 
 int _start(void *a0, void *a1, void *a2) __attribute__((section(".text.start")));
 int _start(void *a0, void *a1, void *a2) {
-	int (* sceBoot)(void *a0, void *a1, void *a2);
+	int (* sceBoot)(void *a0, void *a1, void *a2) = NULL;
 
 	*(u32 *)0x89FF0000 = 0x200;
 	*(u32 *)0x89FF0004 = 0x2;
@@ -269,5 +269,10 @@ int _start(void *a0, void *a1, void *a2) {
 	ClearCaches();
 
 	// Call original function
-	return sceBoot(a0, a1, a2);
+	int res = SCE_ERR_NOT_INIT;
+	// this branch should always happen
+	if (sceBoot != NULL) {
+		res = sceBoot(a0, a1, a2);
+	}
+	return res;
 }

--- a/cef/systemctrl/sysmodpatches.c
+++ b/cef/systemctrl/sysmodpatches.c
@@ -160,8 +160,6 @@ int sctrlHENSetMemory(u32 p2, u32 p11) {
 
 // ARK-4 compat
 int sctrlHENApplyMemory(u32 p2) {
-	int apitype = sceKernelInitApitype();
-
 	if (p2 > 52) {
 		p2 = 52;
 	}


### PR DESCRIPTION
Expose more `iso_common` functions with macro configuration

And fix a couple of warnings.