### PR TITLE
VSH Control stuff

### DIFF
--- a/cef/bits/iso_common.c
+++ b/cef/bits/iso_common.c
@@ -118,7 +118,7 @@ static int read_raw_data(u8* addr, u32 size, u32 offset) {
 			i = 0;
 			break;
 		} else {
-			logmsg("%s: %s lseek retry %d error 0x%08X\n", __func__, g_iso_fn, i, (int)ofs);
+			logmsg("%s: %s(%d) lseek retry %d error 0x%08X\n", __func__, g_iso_fn, g_iso_fd, i, (int)ofs);
 			iso_open();
 		}
 
@@ -226,7 +226,7 @@ static int read_compressed_data(u8* addr, u32 size, u32 offset) {
 	o_end = (o_end&0x7FFFFFFF)<<align;
 	u32 compressed_size = o_end-o_start;
 
-	logmsg4("%s: [DEBUG]: compressed size: %d, ", __func__, compressed_size);
+	logmsg4("%s: [DEBUG]: compressed size: %ld, ", __func__, compressed_size);
 
 	// try to read at once as much compressed data as possible
 	if (size > block_size*2){ // only if going to read more than two blocks
@@ -431,7 +431,10 @@ int iso_alloc(u32 com_size) {
 	return 0;
 }
 
-static void iso_free() {
+#ifndef __ISO_EXTRA__
+static
+#endif // __ISO_EXTRA__
+void iso_free() {
 	#ifdef __USE_USER_ALLOC
 	if (is_compressed) {
 		user_free(g_ciso_dec_buf_alloc_ptr);

--- a/cef/include/iso_common.h
+++ b/cef/include/iso_common.h
@@ -97,6 +97,7 @@ int isoGetGameId(char game_id[10]);
 #ifdef __ISO_EXTRA__
 int iso_type_check(SceUID fd);
 int iso_alloc(u32 com_size);
+void iso_free();
 int iso_re_open(void);
 #endif // __ISO_EXTRA__
 

--- a/cef/systemctrl/main.c
+++ b/cef/systemctrl/main.c
@@ -598,7 +598,7 @@ static int OnModuleStart(SceModule2 *mod) {
 		}
 	}
 
-	logmsg4("%s: [DEBUG]: mod_name=%s — text_addr=0x%08X\n", modname, text_addr);
+	logmsg4("%s: [DEBUG]: mod_name=%s — text_addr=0x%08X\n", __func__, modname, text_addr);
 
 	return 0;
 }

--- a/cef/vshctrl/Makefile
+++ b/cef/vshctrl/Makefile
@@ -1,5 +1,5 @@
 TARGET = vshctrl
-OBJS = main.o registry.o virtualsfo.o virtualpbpmgr.o isofs_driver/isofs_driver.o isofs_driver/umd9660_driver.o isofs_driver/csoread.o exports.o imports.o
+OBJS = main.o registry.o virtualsfo.o virtualpbpmgr.o isofs_driver/isofs_driver.o isofs_driver/umd9660_driver.o isofs_driver/csoread.o exports.o
 
 INCDIR = ../include
 CFLAGS = -Os -G0 -Wall -fshort-wchar -fno-pic -mno-check-zero-division -D__KERNEL__

--- a/cef/vshctrl/Makefile
+++ b/cef/vshctrl/Makefile
@@ -22,7 +22,7 @@ USE_KERNEL_LIBC = 1
 USE_KERNEL_LIBS = 1
 
 LIBDIR = ../lib
-LIBS = -lpspsystemctrl_kernel -lpsppower_driver -lpsprtc_driver -lpspusb_driver -lpspreg_driver
+LIBS = -lpspsystemctrl_kernel -lpsppower_driver -lpsprtc_driver -lpspusb_driver -lpspreg_driver -lpspsysclib_kernel -lpspsysmem_kernel -lpspinit_kernel
 
 PSPSDK = $(shell psp-config --pspsdk-path)
 include $(PSPSDK)/lib/build_prx.mak

--- a/cef/vshctrl/imports.S
+++ b/cef/vshctrl/imports.S
@@ -1,9 +1,0 @@
-	.set noreorder
-
-#include "pspstub.s"
-	STUB_START "SysMemForKernel", 0x00010011, 0x00010005
-	STUB_FUNC 0xEF29061C, sceKernelGetGameInfo
-	STUB_END
-	STUB_START "SysclibForKernel", 0x00010000, 0x00010005
-	STUB_FUNC 0xC2145E80, snprintf
-	STUB_END

--- a/cef/vshctrl/main.c
+++ b/cef/vshctrl/main.c
@@ -18,6 +18,9 @@
 
 #include <common.h>
 
+#define _ADRENALINE_LOG_IMPL_
+#include <adrenaline_log.h>
+
 #include "virtualpbpmgr.h"
 #include "isofs_driver/umd9660_driver.h"
 #include "isofs_driver/isofs_driver.h"
@@ -987,6 +990,9 @@ int OnModuleStart(SceModule2 *mod) {
 }
 
 int module_start(SceSize args, void *argp) {
+	logInit("ms0:/log_vshctrl.txt");
+	logmsg("VshCtrl started\n");
+
 	SceModule2 *mod = sceKernelFindModuleByName("sceLoadExec");
 	u32 text_addr = mod->text_addr;
 

--- a/cef/vshctrl/main.c
+++ b/cef/vshctrl/main.c
@@ -56,6 +56,12 @@ void KXploitString(char *str) {
 }
 
 int CorruptIconPatch(char *name) {
+	// Hide ARK bubble launchers
+	if (strcasecmp(name, "SCPS10084") == 0 || strcasecmp(name, "NPUZ01234") == 0){
+		strcpy(name, "__SCE"); // hide icon
+		return 1;
+	}
+
 	char path[256];
 	sprintf(path, "ms0:/PSP/GAME/%s%%/EBOOT.PBP", name);
 

--- a/cef/vshctrl/virtualpbpmgr.c
+++ b/cef/vshctrl/virtualpbpmgr.c
@@ -213,10 +213,10 @@ int virtualpbp_add(char *isofile, ScePspDateTime *mtime, VirtualPbp *res)
 	{
 		memcpy(res, &vpbps[g_index], sizeof(VirtualPbp));
 	}
+	logmsg("[INFO]: ISO file was added to VirtualPBP list: `%s`\n", vpbps[g_index].isofile);
 
 	g_index++;
 
-	logmsg("[INFO]: %s ISO file was added to VirtualPBP list\n", isofile);
 	sceKernelSignalSema(vpsema, 1);
 	return 0;
 }
@@ -232,10 +232,10 @@ int virtualpbp_fastadd(VirtualPbp *pbp)
 	}
 
 	memcpy(&vpbps[g_index], pbp, sizeof(VirtualPbp));
+	logmsg2("[INFO]: ISO file was added to VirtualPBP list: `%s`\n", vpbps[g_index].isofile);
 
 	g_index++;
 
-	logmsg2("[INFO]: %s ISO file was added to VirtualPBP list\n", vpbps[g_index].isofile);
 	sceKernelSignalSema(vpsema, 1);
 	return 0;
 }

--- a/cef/vshctrl/virtualpbpmgr.c
+++ b/cef/vshctrl/virtualpbpmgr.c
@@ -1,5 +1,7 @@
 #include <common.h>
 
+#include <adrenaline_log.h>
+
 #include "virtualpbpmgr.h"
 #include "isofs_driver/umd9660_driver.h"
 #include "isofs_driver/isofs_driver.h"
@@ -214,6 +216,7 @@ int virtualpbp_add(char *isofile, ScePspDateTime *mtime, VirtualPbp *res)
 
 	g_index++;
 
+	logmsg("[INFO]: %s ISO file was added to VirtualPBP list\n", isofile);
 	sceKernelSignalSema(vpsema, 1);
 	return 0;
 }
@@ -232,6 +235,7 @@ int virtualpbp_fastadd(VirtualPbp *pbp)
 
 	g_index++;
 
+	logmsg2("[INFO]: %s ISO file was added to VirtualPBP list\n", vpbps[g_index].isofile);
 	sceKernelSignalSema(vpsema, 1);
 	return 0;
 }


### PR DESCRIPTION
- Refactor to use archive stubs
- Refactor to use Adrenaline Log
- Hide ARK-4 bubble launchers if the `Hide corrupt` option is enabled (as they won't work from Adrenaline anyway)

Also a small fix to a log message on SystemControl