### PR TITLE
refactor(user): remove unused headers/code, tighten scoping, and fix buffer sizes

### DIFF
--- a/user/main.c
+++ b/user/main.c
@@ -42,6 +42,7 @@
 #include <string.h>
 
 #include "lodepng/lodepng.h"
+#include "lz4/lz4.h"
 
 #include "main.h"
 #include "pops.h"
@@ -52,13 +53,9 @@
 #include "states.h"
 #include "usb.h"
 #include "utils.h"
-#include "msfs.h"
+#include "startdat.h"
 #include "../adrenaline_vita.h"
 #include "../adrenaline_version.h"
-
-#include "lz4/lz4.h"
-
-#include "startdat.h"
 
 
 INCLUDE_EXTERN_RESOURCE(payloadex_bin);
@@ -118,7 +115,7 @@ extern SceInt32 sceLiveAreaUpdateFrameSync(const char *formatVer,const char *fra
 
 int __errno;
 
-void GetFunctions() {
+static void GetFunctions() {
 	ScePspemuDivide                     = (void *)(text_addr + 0x39F0 + 0x1);
 	ScePspemuErrorExit                  = (void *)(text_addr + 0x4104 + 0x1);
 	ScePspemuConvertAddress             = (void *)(text_addr + 0x6364 + 0x1);
@@ -162,7 +159,7 @@ void SendAdrenalineRequest(int cmd) {
 #define LZ4_ACCELERATION 8
 #define SAVESTATE_TEMP_SIZE (32 * 1024 * 1024)
 
-int SaveState(SceAdrenaline *adrenaline, void *savestate_data) {
+static int SaveState(SceAdrenaline *adrenaline, void *savestate_data) {
 	void *ram = (void *)ScePspemuConvertAddress(0x88000000, KERMIT_INPUT_MODE, PSP_RAM_SIZE);
 
 	char path[128];
@@ -213,7 +210,7 @@ int SaveState(SceAdrenaline *adrenaline, void *savestate_data) {
 	return 0;
 }
 
-int LoadState(SceAdrenaline *adrenaline, void *savestate_data) {
+static int LoadState(SceAdrenaline *adrenaline, void *savestate_data) {
 	void *ram = (void *)ScePspemuConvertAddress(0x88000000, KERMIT_OUTPUT_MODE, PSP_RAM_SIZE);
 
 	char path[128];
@@ -261,7 +258,7 @@ int LoadState(SceAdrenaline *adrenaline, void *savestate_data) {
 
 extern vita2d_texture* overlay_texture;
 
-int AdrenalineCompat(SceSize args, void *argp) {
+static int AdrenalineCompat(SceSize args, void *argp) {
 	void *savestate_data = NULL;
 
 	// Allocate savestate temp memory
@@ -369,7 +366,7 @@ int AdrenalineCompat(SceSize args, void *argp) {
 
 			if ( res == 0 ) {
 				char frameXmlStr[512] = {0};
-				res = ReadFile("ux0:app/" ADRENALINE_TITLEID "/frame.xml", frameXmlStr, 512);
+				res = ReadFile("ux0:app/" ADRENALINE_TITLEID "/frame.xml", frameXmlStr, sizeof(frameXmlStr));
 				if (res > 0) {
 					res = sceLiveAreaUpdateFrameSync("01.00", frameXmlStr, strlen(frameXmlStr), "app0:/", 0);
 				}
@@ -502,7 +499,7 @@ static int InitAdrenaline() {
 	return 0;
 }
 
-int sceCompatSuspendResumePatched(int unk) {
+static int sceCompatSuspendResumePatched(int unk) {
 	// Lock USB connection and PS button
 	sceShellUtilLock(SCE_SHELL_UTIL_LOCK_TYPE_USB_CONNECTION | SCE_SHELL_UTIL_LOCK_TYPE_PS_BTN_2);
 
@@ -551,8 +548,8 @@ static int sceCompatWaitSpecialRequestPatched(int mode) {
 	kuCtrlPeekBufferPositive(0, &pad, 1);
 
 	SceIoStat stat;
-	char ark_path[47];
-	snprintf(ark_path, 47, "%s" FLASH0_ARK_PATH, getPspemuMemoryStickLocation());
+	char ark_path[64];
+	snprintf(ark_path, sizeof(ark_path), "%s" FLASH0_ARK_PATH, getPspemuMemoryStickLocation());
 	allow_ark = sceIoGetstat(ark_path, &stat) >= 0 || sceIoGetstat("ux0:pspemu" FLASH0_ARK_PATH, &stat) >= 0;
 
 	if (pad.buttons & SCE_CTRL_RTRIGGER) {
@@ -681,7 +678,7 @@ int module_start(SceSize args, void *argp) {
 		char frameXmlStr[512];
 		snprintf(
 			frameXmlStr,
-			512,
+			sizeof(frameXmlStr),
 			"<frame id=\"frame2\">"
 					"<liveitem>"
 							"<text valign=\"bottom\" align=\"left\" text-align=\"left\" text-valign=\"bottom\" line-space=\"3\" ellipsis=\"on\">"

--- a/user/pops.h
+++ b/user/pops.h
@@ -19,9 +19,7 @@
 #ifndef __POPS_H__
 #define __POPS_H__
 
-#include <psp2/ctrl.h>
 #include <psp2/display.h>
-#include <psp2/io/dirent.h>
 #include <psp2/io/fcntl.h>
 #include <psp2/io/stat.h>
 
@@ -29,7 +27,6 @@ int ScePspemuInitAudioOutPatched();
 int sceAudioOutOpenPortPatched(int type, int len, int freq, int mode);
 int sceAudioOutOutputPatched(int port, const void *buf);
 int ScePspemuDecodePopsAudioPatched(int a1, int a2, int a3, int a4);
-int sceCtrlPeekBufferNegative2Patched(int port, SceCtrlData *pad_data, int count);
 char *ScePspemuGetTitleidPatched();
 int ScePspemuConvertAddressPatched(uint32_t addr, int mode, uint32_t cache_size);
 SceUID sceIoOpenPatched(const char *file, int flags, SceMode mode);

--- a/user/states.c
+++ b/user/states.c
@@ -16,26 +16,19 @@
 	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <psp2/appmgr.h>
-#include <psp2/apputil.h>
-#include <psp2/ctrl.h>
 #include <psp2/display.h>
 #include <psp2/rtc.h>
 #include <psp2/system_param.h>
-#include <psp2/sysmodule.h>
-#include <psp2/power.h>
 #include <psp2/io/dirent.h>
 #include <psp2/io/fcntl.h>
 #include <psp2/io/stat.h>
 #include <psp2/kernel/sysmem.h>
-#include <psp2/kernel/processmgr.h>
+#include <vita2d.h>
 
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <vita2d.h>
 
 #include "main.h"
 #include "menu.h"
@@ -43,9 +36,9 @@
 #include "usb.h"
 #include "utils.h"
 
-AdrenalineStateEntry *states;
+static AdrenalineStateEntry *states;
 
-static int option_sel =  0;
+static int option_sel = 0;
 static int rel_pos = 0, base_pos = 0;
 
 int open_options = 0;
@@ -62,8 +55,8 @@ static char *option_entries_exist[] = {
 	"Cancel",
 };
 
-#define N_OPTION_ENTRIES_NEW (sizeof(option_entries_new) / sizeof(char **))
-#define N_OPTION_ENTRIES_EXIST (sizeof(option_entries_exist) / sizeof(char **))
+#define N_OPTION_ENTRIES_NEW (sizeof(option_entries_new) / sizeof(char *))
+#define N_OPTION_ENTRIES_EXIST (sizeof(option_entries_exist) / sizeof(char *))
 
 #define OPTION_MODE_NEW 0
 #define OPTION_MODE_EXIST 1
@@ -91,7 +84,7 @@ static uint32_t convert565To8888(uint16_t color) {
 	return (alpha << 24) | (red << 16) | (green << 8) | blue;
 }
 
-int saveFrameBuffer(SceUID fd) {
+static int saveFrameBuffer(SceUID fd) {
 	sceCompatLCDCSync();
 
 	uint32_t *buf = malloc(SCREENSHOT_SIZE);
@@ -140,11 +133,11 @@ int saveFrameBuffer(SceUID fd) {
 	return 0;
 }
 
-void saveState(int num) {
+static void saveState(int num) {
 	char path[128];
 
 	// Make dir
-	sprintf(path, "%s/PSP/SAVESTATE", getPspemuMemoryStickLocation());
+	snprintf(path, sizeof(path), "%s/PSP/SAVESTATE", getPspemuMemoryStickLocation());
 	sceIoMkdir(path, 0777);
 
 	makeSaveStatePath(path, num);
@@ -166,7 +159,7 @@ void saveState(int num) {
 	SendAdrenalineRequest(ADRENALINE_PSP_CMD_SAVESTATE);
 }
 
-void loadState(int num) {
+static void loadState(int num) {
 	SceAdrenaline *adrenaline = (SceAdrenaline *)ScePspemuConvertAddress(ADRENALINE_ADDRESS, KERMIT_OUTPUT_MODE, ADRENALINE_SIZE);
 	adrenaline->num = num;
 	ScePspemuWritebackCache(adrenaline, ADRENALINE_SIZE);
@@ -175,7 +168,7 @@ void loadState(int num) {
 	SendAdrenalineRequest(ADRENALINE_PSP_CMD_LOADSTATE);
 }
 
-void deleteState(int num) {
+static void deleteState(int num) {
 	char path[128];
 	makeSaveStatePath(path, num);
 
@@ -221,7 +214,7 @@ int initStates() {
 
 	// Load savestates
 	char folder[128];
-	sprintf(folder, "%s/PSP/SAVESTATE", getPspemuMemoryStickLocation());
+	snprintf(folder, sizeof(folder), "%s/PSP/SAVESTATE", getPspemuMemoryStickLocation());
 
 	SceUID dfd = sceIoDopen(folder);
 	if (dfd >= 0) {
@@ -318,10 +311,10 @@ void drawStates() {
 			pgf_draw_text(250.0f, FONT_Y_LINE(2 + i * 5), WHITE, FONT_SIZE, states[base_pos + i].title);
 
 			// Date & time
-			char date_string[16];
+			char date_string[24];
 			getDateString(date_string, date_format, &states[base_pos + i].time);
 
-			char time_string[24];
+			char time_string[16];
 			getTimeString(time_string, time_format, &states[base_pos + i].time);
 
 			pgf_draw_textf(250.0f, FONT_Y_LINE(3 + i * 5), WHITE, FONT_SIZE, "%s %s", date_string, time_string);

--- a/user/usb.c
+++ b/user/usb.c
@@ -18,7 +18,6 @@
 
 #include <psp2/appmgr.h>
 #include <psp2/mtpif.h>
-#include <psp2/udcd.h>
 #include <psp2/usbstorvstor.h>
 #include <psp2/io/dirent.h>
 
@@ -33,7 +32,7 @@
 int _vshIoMount(int id, const char *path, int permission, void *buf);
 int vshIoUmount(int id, int a2, int a3, int a4);
 
-int vshIoMount(int id, const char *path, int permission, int a4, int a5, int a6) {
+static int vshIoMount(int id, const char *path, int permission, int a4, int a5, int a6) {
 	uint32_t buf[3];
 
 	buf[0] = a4;
@@ -43,13 +42,13 @@ int vshIoMount(int id, const char *path, int permission, int a4, int a5, int a6)
 	return _vshIoMount(id, path, permission, buf);
 }
 
-void remount(int id) {
+static void remount(int id) {
 	vshIoUmount(id, 0, 0, 0);
 	vshIoUmount(id, 1, 0, 0);
 	vshIoMount(id, NULL, 0, 0, 0, 0);
 }
 
-int checkFolderExist(const char *folder) {
+static int checkFolderExist(const char *folder) {
 	SceUID dfd = sceIoDopen(folder);
 	if (dfd < 0) {
 		return 0;

--- a/user/utils.c
+++ b/user/utils.c
@@ -20,10 +20,7 @@
 #include <psp2/display.h>
 #include <psp2/rtc.h>
 #include <psp2/system_param.h>
-#include <psp2/io/dirent.h>
 #include <psp2/io/fcntl.h>
-#include <psp2/io/stat.h>
-#include <psp2/kernel/modulemgr.h>
 #include <psp2/kernel/sysmem.h>
 #include <psp2/kernel/processmgr.h>
 
@@ -36,16 +33,14 @@
 #include "utils.h"
 
 Pad old_pad, current_pad, pressed_pad, released_pad, hold_pad, hold2_pad;
-Pad hold_count, hold2_count;
-
-int SCE_CTRL_ENTER = SCE_CTRL_CROSS, SCE_CTRL_CANCEL = SCE_CTRL_CIRCLE;
+static Pad hold_count, hold2_count;
 
 int debugPrintf(char *text, ...) {
 	va_list list;
 	char string[512];
 
 	va_start(list, text);
-	vsprintf(string, text, list);
+	vsnprintf(string, sizeof(string), text, list);
 	va_end(list);
 
 	SceUID fd = sceIoOpen("ux0:data/adrenaline_user_log.txt", SCE_O_WRONLY | SCE_O_CREAT | SCE_O_APPEND, 0777);
@@ -246,7 +241,7 @@ void getSizeString(char string[16], uint64_t size) {
 	snprintf(string, 16, "%.*lld %s", (i == 0) ? 0 : 2, size, units[i]);
 }
 
-void convertUtcToLocalTime(SceDateTime *time_local, SceDateTime *time_utc) {
+static void convertUtcToLocalTime(SceDateTime *time_local, SceDateTime *time_utc) {
 	SceRtcTick tick;
 	sceRtcGetTick(time_utc, &tick);
 	sceRtcConvertUtcToLocalTime(&tick, &tick);

--- a/user/utils.h
+++ b/user/utils.h
@@ -56,7 +56,6 @@ enum PadButtons {
 typedef uint8_t Pad[PAD_N_BUTTONS];
 
 extern Pad old_pad, current_pad, pressed_pad, released_pad, hold_pad, hold2_pad;
-extern Pad hold_count, hold2_count;
 
 int debugPrintf(char *text, ...);
 int ReadFile(char *file, void *buf, int size);


### PR DESCRIPTION
- Remove unused and duplicated headers across user modules
- Remove unused declarations and dead variables (sceCtrlPeekBufferNegative2Patched, SCE_CTRL_ENTER, SCE_CTRL_CANCEL)
- Scope internal functions and variables to static in main.c, states.c, usb.c, and utils.c
- Improve buffer safety using sizeof in snprintf/vsnprintf and expand ark_path to 64 bytes
- Fix potential buffer overflow in states.c by expanding date_string to match getDateString